### PR TITLE
Get aircraft based on airport bounding square

### DIFF
--- a/arrivalboard/app.py
+++ b/arrivalboard/app.py
@@ -14,7 +14,7 @@ def run():
     airports = airport_source.get_airports()
 
     arrivals = ArrivalsService(OpenSkyApi())
-    aircraft = arrivals.get_aircraft(airports["KORD"].runways[0])
+    aircraft = arrivals.get_aircraft(airports["KORD"])
 
     for a in aircraft:
         print(a)

--- a/arrivalboard/config/airports/kord.toml
+++ b/arrivalboard/config/airports/kord.toml
@@ -1,10 +1,7 @@
 icao_code = "KORD"
 name = "Chicago O'Hare International Airport"
-
-boundary_lat_min = 999
-boundary_lon_min = 999
-boundary_lat_max = 999
-boundary_lon_max = 999
+lat = 41.978611
+lon = -87.904724
 
 [runways]
 

--- a/arrivalboard/data/adsb.py
+++ b/arrivalboard/data/adsb.py
@@ -3,14 +3,11 @@ from abc import abstractmethod
 from typing import List
 
 from models.aircraft import Aircraft
+from models.airport import Airport
 
 
 class ADSBSource(ABC):
 
     @abstractmethod
-    def get_aircraft(self,
-                     lat_min: float,
-                     lon_min: float,
-                     lat_max: float,
-                     lon_max: float) -> List[Aircraft]:
+    def get_aircraft(self, airport: Airport) -> List[Aircraft]:
         pass

--- a/arrivalboard/helpers/latlon.py
+++ b/arrivalboard/helpers/latlon.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BoundingSquare:
+    lat_min: float
+    lon_min: float
+    lat_max: float
+    lon_max: float
+
+
+def get_bounding_square_from_point(lat: float, lon: float, radius: int) -> BoundingSquare:
+    lat_deg, lat_mins, lat_secs = to_deg_min_sec(lat)
+    lon_deg, lon_mins, lon_secs = to_deg_min_sec(lon)
+
+    lat_dist_secs = _distance_to_secs(radius, 101)
+    lon_dist_secs = _distance_to_secs(radius, 80)
+
+    lat_mins_diff = int(lat_dist_secs / 60)
+    lat_secs_diff = lat_dist_secs - (lat_mins_diff * 60)
+
+    lon_mins_diff = int(lon_dist_secs / 60)
+    lon_secs_diff = lon_dist_secs - (lon_mins_diff * 60)
+
+    return BoundingSquare(
+        lat_min=to_decimal(lat_deg, lat_mins - lat_mins_diff, lat_secs - lat_secs_diff),
+        lon_min=to_decimal(lon_deg, lon_mins - lon_mins_diff, lon_secs - lon_secs_diff),
+        lat_max=to_decimal(lat_deg, lat_mins + lat_mins_diff, lat_secs + lat_secs_diff),
+        lon_max=to_decimal(lon_deg, lon_mins + lon_mins_diff, lon_secs + lon_secs_diff),
+    )
+
+
+def _distance_to_secs(radius: int, feet_per_sec: int) -> float:
+    radius_ft = radius * 5280
+    return round(radius_ft / feet_per_sec, 4)
+
+
+def to_deg_min_sec(coord: float) -> (int, int, int):
+    deg = int(coord)
+    min = int((coord - deg) * 60)
+    sec = int((round((coord - deg) * 60, 4) - min) * 60)
+    return (deg, min, sec)
+
+
+def to_decimal(deg: int, min: int, sec: int) -> float:
+    return (((sec / 60) + min) / 60) + deg

--- a/arrivalboard/models/airport.py
+++ b/arrivalboard/models/airport.py
@@ -15,8 +15,6 @@ class Runway:
 class Airport:
     icao_code: str
     name: str
-    boundary_lat_min: float
-    boundary_lon_min: float
-    boundary_lat_max: float
-    boundary_lon_max: float
+    lat: float
+    lon: float
     runways: List[Runway]

--- a/arrivalboard/services/arrivals.py
+++ b/arrivalboard/services/arrivals.py
@@ -2,6 +2,7 @@ from typing import List
 
 from data.adsb import ADSBSource
 from models.aircraft import Aircraft
+from models.airport import Airport
 from models.airport import Runway
 
 
@@ -10,8 +11,5 @@ class ArrivalsService:
     def __init__(self, adsb_source: ADSBSource):
         self.adsb_source = adsb_source
 
-    def get_aircraft(self, runway: Runway) -> List[Aircraft]:
-        return self.adsb_source.get_aircraft(lat_min=runway.final_lat_min,
-                                             lon_min=runway.final_lon_min,
-                                             lat_max=runway.final_lat_max,
-                                             lon_max=runway.final_lon_max)
+    def get_aircraft(self, airport: Airport) -> List[Aircraft]:
+        return self.adsb_source.get_aircraft(airport)


### PR DESCRIPTION
Rework approach for how to define the lat / long coordinates that are used to request aircraft data from OpenSky's API.