### PR TITLE
Sort aircraft by proximity to airport

### DIFF
--- a/arrivalboard/traffic.py
+++ b/arrivalboard/traffic.py
@@ -1,20 +1,41 @@
+from typing import Callable
+
 from arrivalboard.aircraft.data import ADSBSource
 from arrivalboard.aircraft.models import Aircraft
-from arrivalboard.airport.data import AirportSource
+from arrivalboard.airport.models import Airport
 from arrivalboard.airport.models import Runway
+from arrivalboard.latlon import Coordinate
+from arrivalboard.latlon import get_distance_between_points
 
 
-class TrafficService:
+def proximity_sorter(airport: Airport) -> Callable:
+    """Return a function that will sort aircraft that are passed to it
+    based on their distance to the specified airport.
 
-    def __init__(self, adsb_source: ADSBSource, airport_source: AirportSource):
+    Keyword arguments:
+    airport -- the airport to use for calculating the aircraft's distance"""
+    def sorter(aircraft: Aircraft):
+        coord_a = Coordinate(airport.lat, airport.lon)
+        coord_b = Coordinate(aircraft.lat, aircraft.lon)
+        return get_distance_between_points(coord_a, coord_b)
+
+    return sorter
+
+
+class Traffic:
+
+    def __init__(self, adsb_source: ADSBSource):
         self.adsb_source = adsb_source
-        self.airports = airport_source.get_airports()
 
-    def get_resolved_by_runway(self, airport_icao_code: str) -> dict[str, Aircraft]:
-        airport = self.airports[airport_icao_code]
+    def resolve_by_runway(self, airport: Airport, sorter_func: Callable) -> dict[str, Aircraft]:
+        """Return aircraft traffic that is assigned to runways they are on approach to.
+
+        Keyword arguments:
+        airport -- the airport to get traffic for
+        sorter_func -- function to use for sorting the list of aircraft resolved to each runway"""
         aircraft = self.adsb_source.get_aircraft(airport)
 
-        runway_aircraft = {}
+        runway_aircraft: dict[str, list[Aircraft]] = {}
         for runway in airport.runways.values():
             runway_aircraft[runway.designator] = []
 
@@ -24,6 +45,9 @@ class TrafficService:
                 if self._is_on_final(aircraft, runway):
                     runway_aircraft[runway.designator].append(aircraft)
                     continue
+
+        for runway, aircraft in runway_aircraft.items():
+            aircraft.sort(key=sorter_func)
 
         return runway_aircraft
 

--- a/run.py
+++ b/run.py
@@ -2,7 +2,8 @@ from arrivalboard.aircraft.data import OpenSkyApi
 from arrivalboard.airport.data import AirportTomlReader
 from arrivalboard.config import APP_CONFIG
 from arrivalboard.config import init_config
-from arrivalboard.traffic import TrafficService
+from arrivalboard.traffic import proximity_sorter
+from arrivalboard.traffic import Traffic
 
 
 def run():
@@ -10,8 +11,13 @@ def run():
 
     print(f"Running with application config:\n{APP_CONFIG}\n")
 
-    traffic = TrafficService(adsb_source=OpenSkyApi(), airport_source=AirportTomlReader())
-    aircraft = traffic.get_resolved_by_runway("KORD")
+    airport_source = AirportTomlReader()
+    airport = airport_source.get_airports()["KORD"]
+
+    traffic = Traffic(adsb_source=OpenSkyApi())
+    sorter = proximity_sorter(airport)
+
+    aircraft = traffic.resolve_by_runway(airport=airport, sorter_func=sorter)
 
     print(aircraft)
 


### PR DESCRIPTION
Add the ability to sort aircraft traffic resolved to each runway. For now, sort aircraft by proximity to the airport.